### PR TITLE
Parse lines with quoted substrings right

### DIFF
--- a/cmd_protocolinfo.go
+++ b/cmd_protocolinfo.go
@@ -10,6 +10,8 @@ package bulb
 import (
 	"strconv"
 	"strings"
+
+	"github.com/yawning/bulb/utils"
 )
 
 // ProtocolInfo is the result of the ProtocolInfo command.
@@ -50,7 +52,7 @@ func (c *Conn) ProtocolInfo() (*ProtocolInfo, error) {
 	pi.RawResponse = resp
 	pi.AuthMethods = make(map[string]bool)
 	for i := 1; i < len(resp.Data); i++ {
-		splitLine := strings.Split(resp.Data[i], " ")
+		splitLine := utils.SplitQuoted(resp.Data[i], '"', ' ')
 		switch splitLine[0] {
 		case "AUTH":
 			// Parse an AuthLine detailing how to authenticate.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,6 +15,24 @@ import (
 	"strconv"
 )
 
+// SplitQuoted splits s by sep if it is found outside substring
+// quoted by quote.
+func SplitQuoted(s string, quote, sep rune) (splitted []string) {
+        quoteFlag := false
+NewSubstring:
+        for i, c := range s {
+                if c == quote {
+                        quoteFlag = !quoteFlag
+                }
+                if c == sep && !quoteFlag {
+                        splitted = append(splitted, s[:i])
+                        s = s[i+1:]
+                        goto NewSubstring
+                }
+        }
+        return append(splitted, s)
+}
+
 // ParseControlPortString parses a string representation of a control port
 // address into a network/address string pair suitable for use with "dial".
 //


### PR DESCRIPTION
E.g. authentication is broken if there are spaces in the path to a auth cookie. Like default TBB's one on OS X/macOS:
`AUTH METHODS=COOKIE,SAFECOOKIE,HASHEDPASSWORD COOKIEFILE="/Users/nogoegst/Library/Application Support/TorBrowser-Data/Tor/control_auth_cookie"`
