### PR TITLE
Make AddOnion use special config structs

### DIFF
--- a/examples/listener/listener.go
+++ b/examples/listener/listener.go
@@ -55,7 +55,11 @@ func main() {
 	}
 	log.Printf("Expected ID: %v", id)
 
-	l, err := c.Listener(80, pk)
+	cfg := &bulb.NewOnionConfig{
+		DiscardPK: true,
+		PrivateKey: pk,
+	}
+	l, err := c.NewListener(cfg, 80)
 	if err != nil {
 		log.Fatalf("Failed to get Listener: %v", err)
 	}

--- a/listener.go
+++ b/listener.go
@@ -1,8 +1,8 @@
 // listener.go - Tor backed net.Listener.
 //
-// To the extent possible under law, Yawning Angel waived all copyright
-// and related or neighboring rights to bulb, using the creative
-// commons "cc0" public domain dedication. See LICENSE or
+// To the extent possible under law, Yawning Angel and Ivan Markin
+// waived all copyright and related or neighboring rights to bulb, using
+// the creative commons "cc0" public domain dedication. See LICENSE or
 // <http://creativecommons.org/publicdomain/zero/1.0/> for full details.
 
 package bulb
@@ -49,17 +49,23 @@ func (l *onionListener) Addr() net.Addr {
 	return l.addr
 }
 
-// Listener returns a net.Listener backed by a Onion Service, optionally
-// having Tor generate an ephemeral private key.  Regardless of the status of
-// the returned Listener, the Onion Service will be torn down when the control
-// connection is closed.
-//
-// WARNING: Only one port can be listened to per PrivateKey if this interface
-// is used.  To bind to more ports, use the  AddOnion call directly.
-func (c *Conn) Listener(port uint16, key crypto.PrivateKey) (net.Listener, error) {
-	const (
-		loopbackAddr = "127.0.0.1:0"
-	)
+// NewListener returns a net.Listener backed by an Onion Service using configuration
+// config, optionally having Tor generate an ephemeral private key (config is nil or
+// config.PrivateKey is nil).
+// All of virtual ports specified in vports will be mapped to the port to which
+// the underlying TCP listener binded. PortSpecs in config will be ignored since
+// there is only one mapping for a vports set is possible.
+func (c *Conn) NewListener(config *NewOnionConfig, vports ...uint16) (net.Listener, error) {
+	var cfg NewOnionConfig
+	if config == nil {
+		cfg = NewOnionConfig{
+			DiscardPK: true,
+		}
+	} else {
+		cfg = *config
+	}
+
+	const loopbackAddr = "127.0.0.1:0"
 
 	// Listen on the loopback interface.
 	tcpListener, err := net.Listen("tcp4", loopbackAddr)
@@ -72,16 +78,39 @@ func (c *Conn) Listener(port uint16, key crypto.PrivateKey) (net.Listener, error
 		return nil, newProtocolError("failed to extract local port")
 	}
 
+	if len(vports) < 1 {
+		return nil, newProtocolError("no virual ports specified")
+	}
+	targetPortStr := strconv.FormatUint((uint64)(tAddr.Port), 10)
+	var portSpecs []OnionPortSpec
+	for _, vport := range vports {
+		portSpecs = append(portSpecs, OnionPortSpec{
+			VirtPort: vport,
+			Target:   targetPortStr,
+		})
+	}
+	cfg.PortSpecs = portSpecs
 	// Create the onion.
-	ports := []OnionPortSpec{{port, strconv.FormatUint((uint64)(tAddr.Port), 10)}}
-	oi, err := c.AddOnion(ports, key, key == nil)
+	oi, err := c.NewOnion(&cfg)
 	if err != nil {
 		tcpListener.Close()
 		return nil, err
 	}
 
-	oa := &onionAddr{info: oi, port: port}
+	oa := &onionAddr{info: oi, port: vports[0]}
 	ol := &onionListener{addr: oa, ctrlConn: c, listener: tcpListener}
 
 	return ol, nil
+}
+
+// [DEPRECATED] Listener returns a net.Listener backed by an Onion Service.
+func (c *Conn) Listener(port uint16, key crypto.PrivateKey) (net.Listener, error) {
+	cfg := &NewOnionConfig{}
+	if key != nil {
+		cfg.PrivateKey = key
+		cfg.DiscardPK = false
+	} else {
+		cfg.DiscardPK = true
+	}
+	return c.NewListener(cfg, port)
 }


### PR DESCRIPTION
It's hard to extend `AddOnion` now.  I rewrote it to use config struct that one can fill with needed data and it should be easy to add more fields to that.
Corresponding changes to Listener, also make Listener use multiple
virtual ports. 

Beware, it breaks API.