### PR TITLE
Trim trailing CRLF from dot-encoded data

### DIFF
--- a/response.go
+++ b/response.go
@@ -112,7 +112,7 @@ func (c *Conn) ReadResponse() (*Response, error) {
 			if c.debugLog {
 				log.Printf("S: [dot encoded data]")
 			}
-			resp.Data = append(resp.Data, string(dotBody))
+			resp.Data = append(resp.Data, strings.TrimRight(string(dotBody), "\n\r"))
 			dotLines := strings.Split(string(dotBody), "\n")
 			for _, dotLine := range dotLines[:len(dotLines)-1] {
 				resp.RawLines = append(resp.RawLines, dotLine)


### PR DESCRIPTION
Trailing CRLF is not a part of the dot-encoded response. It's hard to trim this from RespData afterwards because it gets mixed with long replies that do not contain newlines at the end.